### PR TITLE
Add support for $DESTDIR

### DIFF
--- a/makefile
+++ b/makefile
@@ -106,12 +106,10 @@ clean:
 	rm -f $(ODIR)/*.o $(BINDIR)/$(LIBOUT) $(BINDIR)/plugins/*.so 
 
 install: $(BINDIR)/$(LIBOUT)
-	@if [ ! -d /usr/include/spm ]; then mkdir /usr/include/spm; fi
-	for i in include/*; do install -vDm 755 $$i /usr/include/spm/; done
-	install -vDm 755 $(BINDIR)/$(LIBOUT) $(DESTDIR)/lib/$(LIBOUT) 
+	@if [ ! -d $(DESTDIR)/usr/include/spm ]; then mkdir -p $(DESTDIR)/usr/include/spm; fi
+	for i in include/*; do install -vDm 755 $$i $(DESTDIR)/usr/include/spm/; done
+	install -vDm 755 $(BINDIR)/$(LIBOUT) $(DESTDIR)/usr/lib/$(LIBOUT)
 	install  $(BINDIR)/plugins/ecmp.so -vDm 755 $(DESTDIR)/var/cccp/plugins/ecmp.so
 
-
-	
 
 


### PR DESCRIPTION
This commit modifies the install target in the Makefile to allow installation to a custom root directory.
Example usage:
```bash
make DESTDIR=/path/to/custom/root install
```