### PR TITLE
Silenced Warnings

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -36,6 +36,9 @@ int f_create_binary_from_source(const char* src_path, const char* bin_path, cons
 {
     struct package pkg;
 
+    (void)in_format;
+    (void)out_format;
+    
     // Open the package source
     open_pkg(src_path, &pkg, NULL);
 

--- a/src/install.c
+++ b/src/install.c
@@ -43,6 +43,8 @@ Returns:
 int f_install_package_source(const char* spm_path, int as_dep, char* repo) {
     // Check if spm_path is NULL
 
+   (void)as_dep;
+    
     if (spm_path == NULL) {
         msg(ERROR, "spm_path is NULL");
         return -1;
@@ -313,6 +315,8 @@ Returns:
 int install_package_binary(const char* archivePath, int as_dep, const char* repo) {
 
     struct package pkg;
+
+    (void)as_dep;
 
     // Get required environment variables
     char* default_format = getenv("SOVIET_DEFAULT_FORMAT");

--- a/src/make.c
+++ b/src/make.c
@@ -215,6 +215,8 @@ Returns:
 */
 int exec_special(const char* cmd, const char* package_dir) {
     dbg(2, "Executing special command: %s", cmd);
+	
+    (void)package_dir;
 
     if (system(cmd) != 0) {
         return 1;

--- a/src/remove.c
+++ b/src/remove.c
@@ -23,6 +23,10 @@ This function is used as a callback by the nftw function to unlink (remove) file
 */
 int unlink_cb(const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf)
 {
+    (void)sb;
+    (void)typeflag;
+    (void)ftwbuf;
+  
     int rv = remove(fpath);
 
     if (rv)


### PR DESCRIPTION
Silenced the following errors:

src/create.c:35:89: warning: unused parameter ‘in_format’ [-Wunused-parameter]
   35 | _from_source(const char* src_path, const char* bin_path, const char* in_format, const char* out_format)
      |                                                          ~~~~~~~~~~~~^~~~~~~~~

src/create.c:35:112: warning: unused parameter ‘out_format’ [-Wunused-parameter]
   35 | * src_path, const char* bin_path, const char* in_format, const char* out_format)
      |                                                          ~~~~~~~~~~~~^~~~~~~~~~

src/install.c:43:56: warning: unused parameter ‘as_dep’ [-Wunused-parameter]
   43 | int f_install_package_source(const char* spm_path, int as_dep, char* repo) {
      |                                                    ~~~~^~~~~~

src/install.c:313:57: warning: unused parameter ‘as_dep’ [-Wunused-parameter]
  313 | int install_package_binary(const char* archivePath, int as_dep, const char* repo) {
      |                                                     ~~~~^~~~~~

src/make.c:216:47: warning: unused parameter ‘package_dir’ [-Wunused-parameter]
  216 | int exec_special(const char* cmd, const char* package_dir) {
      |                                   ~~~~~~~~~~~~^~~~~~~~~~~

src/remove.c:24:53: warning: unused parameter ‘sb’ [-Wunused-parameter]
   24 | int unlink_cb(const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf)
      |                                  ~~~~~~~~~~~~~~~~~~~^~
src/remove.c:24:61: warning: unused parameter ‘typeflag’ [-Wunused-parameter]
   24 | int unlink_cb(const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf)
      |                                                         ~~~~^~~~~~~~
src/remove.c:24:83: warning: unused parameter ‘ftwbuf’ [-Wunused-parameter]
   24 | k_cb(const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf)
      |                                                              ~~~~~~~~~~~~^~~~~~